### PR TITLE
add getClientHistory() call to fetch history of client interactions

### DIFF
--- a/omada/omada.py
+++ b/omada/omada.py
@@ -518,3 +518,19 @@ class Omada:
 	##
 	def getWirelessNetworks(self, group, site=None):
 		return self.__get( f'/sites/{self.__findKey(site)}/setting/wlans/{group}/ssids' )
+
+	##
+	## Returns client history based on clients mac adress
+	##
+	## Function does not validate mac address, use getSiteClients() to find clients of interest.
+	## timeStart and timeEnd are in unix timestamps (type int)
+	##
+	def getClientHistory(self, clientmac, site=None, timeStart = None, timeEnd = None):
+		params = dict()
+
+		if timeStart is not None:
+			params["filters.timeStart"] = int(timeStart)
+		if timeEnd is not None:
+			params["filters.timeEnd"] = int(timeEnd)
+
+		return self.__geterator(f"/sites/{self.__findKey(site)}/clientHistory/{clientmac}", params=params)


### PR DESCRIPTION
Probably only works if history collection is enabled. The ui certainly checks for it, but i just needed this function, so i only implemented that one call. 