### PR TITLE
get Clients of certain AP

### DIFF
--- a/omada/omada.py
+++ b/omada/omada.py
@@ -436,6 +436,15 @@ class Omada:
 		return self.__geterator( f'/sites/{self.__findKey(site)}/clients', params={'filters.active':'true'} )
 
 	##
+	##  Returns the list of active clients for given AP and site.
+	##
+	def getAPClients(self, site=None, apmac=None):
+	        return self.__geterator(
+	            f"/sites/{self.__findKey(site)}/clients",
+	            params={"filters.active": "true", "filters.apMac": apmac},
+	        )
+	
+	##
 	## Returns the list of alerts for given site.
 	##
 	def getSiteAlerts(self, site=None, archived=False, level=None, module=None, searchKey=None):


### PR DESCRIPTION
Query all the online clients of a certain AP (add function with filter on apMac to get Clients by AP)
![image](https://github.com/ghaberek/omada-api/assets/5702338/cdf5b7a0-8dfd-4abd-9372-d0c8a12f8c1e)


i dont know if the naming of the function is right feel free to change it