### PR TITLE
Add options to make WAN port Internet State enable or disable

### DIFF
--- a/internet-status.py
+++ b/internet-status.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import sys
+from omada import Omada
+
+def main():
+	if len(sys.argv) < 2 or (len(sys.argv) > 1 and sys.argv[1] not in ('enable','disable')):
+		print( f"usage: {sys.argv[0]} [enable|disable]" )
+		return
+
+	omada = Omada()
+	omada.login()
+
+	devices = omada.getSiteDevices()
+	if len(devices) > 0:
+		gateway = next((device for device in devices if device['type'] == 'gateway'), None)
+		print(f"Selected gateway: {gateway}")
+		if gateway:
+			mac = gateway['mac']
+		else:
+			print( 'No gateway device found' )
+			return
+		
+		omada.setInternetStatus(mac=mac, port_id=1, enable=sys.argv[1] == 'enable')
+		gateway = omada.getGatewayDevice(mac=mac)
+		print( f'Updated gateway: {gateway}' )
+
+	omada.logout()
+
+if __name__ == '__main__':
+	main()

--- a/omada/omada.py
+++ b/omada/omada.py
@@ -590,3 +590,20 @@ class Omada:
 	##
 	def getWirelessNetworks(self, group, site=None):
 		return self.__get( f'/sites/{self.__findKey(site)}/setting/wlans/{group}/ssids' )
+
+	##
+	## Returns the gateway device specified by the MAC address.
+	##
+	## This is a Gateway device listed on Device List.
+	##
+	def getGatewayDevice(self, mac, site=None):
+		return self.__get( f'/sites/{self.__findKey(site)}/gateways/{mac}' )
+	
+	##
+	## Control the internet status of a WAN port in a gateway device specified by the MAC address.
+	##
+	## enable = True, Make WAN port connected.
+	## enable = False, Make WAN port disconnected.
+	##
+	def setInternetStatus(self, mac, port_id, enable, site=None):
+		return self.__post( f'/sites/{self.__findKey(site)}/cmd/gateways/{mac}/internetState', json={'portId': port_id, 'operation': 1 if enable else 0} )


### PR DESCRIPTION
This is adding 2 new functions to Omada class for following:

1. Returns the gateway device specified by the MAC address.
2. Control the internet status of a WAN port in a gateway device specified by the MAC address.

Currently Omada itself does not provide a way to schedule WAN port connectivity. With the given `internet-service.py` sample, someone can schedule a cron to enable or disable internet access for a given WAN port as required.